### PR TITLE
Use python-mimeparse in install_requires

### DIFF
--- a/recipe/0001-Require-python-mimeparse.patch
+++ b/recipe/0001-Require-python-mimeparse.patch
@@ -1,0 +1,25 @@
+From ee69f78d2d64cab3d2a938eda3b43a4741ecc6eb Mon Sep 17 00:00:00 2001
+From: Jakob van Santen <jvansanten@gmail.com>
+Date: Tue, 7 Sep 2021 13:46:30 +0200
+Subject: [PATCH] Require python-mimeparse
+
+---
+ setup.cfg | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.cfg b/setup.cfg
+index a5d131b..ba012f0 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -40,7 +40,7 @@ license = BSD
+ url = https://github.com/astropy/pyvo
+ edit_on_github = False
+ github_project = astropy/pyvo
+-install_requires = astropy requests mimeparse
++install_requires = astropy requests python-mimeparse
+ # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
+ version = 1.1
+ 
+-- 
+2.30.2
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,10 +9,12 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: e14f527ecbec48b71d57f48f301ec6a809f886096114529cf2d1fdcbaf6deb2b
+  patches:
+    - 0001-Require-python-mimeparse.patch
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python setup.py install --offline --no-git --single-version-externally-managed --record=files.txt
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

The upstream setup.py lists `mimeparse` in its `install_requires`, while the recipe uses `python-mimeparse` as a drop-in replacement. Patch the upstream package to list `python-mimeparse` in its requirements instead to prevent `pip check` from flagging the environment as broken.

<!--
Please add any other relevant info below:
-->
